### PR TITLE
Specify docker tag that works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM trzeci/emscripten
+FROM trzeci/emscripten:sdk-tag-1.38.30-64bit
 
 RUN apt-get update && apt-get install -y autoconf libtool
 


### PR DESCRIPTION
The latest `trzeci/emscripten` container doesn't seem to be compatible with the code.